### PR TITLE
Add downloadable import template and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# PageLayout
+
+## Modello JSON per l'import automatico
+
+1. Apri il menu Impostazioni dell'interfaccia e usa l'azione **Scarica modello JSON** (elemento `#tbDownloadTemplate`) per ottenere `modello-import.json`.
+2. Compila i campi `placeholders`, `sectionTitles`, `image`, `mermaid`, `glossario` e `quiz` con i contenuti della tua lezione.
+3. Importa il file completo tramite il pulsante **Importa** oppure incolla il JSON nel dialog dedicato.
+
+Il modello riproduce la struttura attesa dalla funzione `ingestData`, quindi ogni campo verrà applicato automaticamente alla pagina.

--- a/demo-contenuti-emozioni.json
+++ b/demo-contenuti-emozioni.json
@@ -5,6 +5,7 @@
     "TOOLTIP_IMPORTA": "Importa da file JSON",
     "TOOLTIP_INCOLLA": "Incolla JSON generato",
     "TOOLTIP_ESPORTA": "Esporta pagina completa",
+    "TOOLTIP_MODELLO": "Scarica il modello JSON di partenza",
     "SCOP0_IN_2_RIGHE": "Riconoscere cos'è un'emozione.\nDistinguere emozione, sentimento e umore.",
     "PUNTO_CALDO_1": "Quando l'emozione aiuta a decidere",
     "PUNTO_CALDO_2": "Quando l'emozione confonde la decisione",

--- a/index.html
+++ b/index.html
@@ -1349,6 +1349,28 @@ function announce(msg){ live.textContent=msg; }
   }
 
   document.addEventListener('DOMContentLoaded', ensureToolbarButtons);
+  document.addEventListener('DOMContentLoaded', function(){
+    const trigger=document.getElementById('tbDownloadTemplate');
+    if(!trigger || trigger.dataset.bindDownload==='true') return;
+    trigger.dataset.bindDownload='true';
+    if(!trigger.getAttribute('title')){
+      trigger.setAttribute('title','[TOOLTIP_MODELLO]');
+    }
+    if(trigger.tagName==='A'){
+      trigger.setAttribute('href','modello-import.json');
+      trigger.setAttribute('download','modello-import.json');
+    }else{
+      trigger.addEventListener('click', function(){
+        const link=document.createElement('a');
+        link.href='modello-import.json';
+        link.download='modello-import.json';
+        link.hidden=true;
+        document.body.appendChild(link);
+        link.click();
+        setTimeout(()=>link.remove(),0);
+      });
+    }
+  });
 })();
 </script>
 <!-- ==== /UPGRADE PACK ==== -->

--- a/modello-import.json
+++ b/modello-import.json
@@ -1,0 +1,70 @@
+{
+  "placeholders": {
+    "TITOLO_ARGOMENTO": "Inserisci il titolo sintetico della lezione (3–6 parole).",
+    "META_DESCRIZIONE": "Breve descrizione per i motori di ricerca (120–150 caratteri).",
+    "TOOLTIP_IMPORTA": "Testo per il tooltip del pulsante Importa.",
+    "TOOLTIP_INCOLLA": "Testo per il tooltip del pulsante Incolla contenuti.",
+    "TOOLTIP_ESPORTA": "Testo per il tooltip del pulsante Esporta.",
+    "TOOLTIP_MODELLO": "Testo per il tooltip di download del modello JSON.",
+    "SCOP0_IN_2_RIGHE": "Due frasi sugli obiettivi di apprendimento.",
+    "UTILITÀ_IN_2_RIGHE": "Descrivi in quale situazione reale serve la lezione.",
+    "PREREQUISITI": "Elenca 2–4 prerequisiti essenziali.",
+    "PUNTO_CALDO_1": "Titolo breve del primo punto caldo.",
+    "PUNTO_CALDO_2": "Titolo breve del secondo punto caldo.",
+    "DEFINIZIONE_OPERATIVA": "Definizione operativa del concetto chiave.",
+    "MODULO_1_TITOLO": "Titolo della prima tappa del percorso.",
+    "MODULO_1_DEFINIZIONE": "Sintesi in 1 riga della prima tappa.",
+    "MODULO_1_APPROFONDIMENTO": "Nota o link di approfondimento opzionale.",
+    "MODULO_2_TITOLO": "Titolo della seconda tappa del percorso.",
+    "MODULO_2_DEFINIZIONE": "Sintesi in 1 riga della seconda tappa.",
+    "MODULO_2_APPROFONDIMENTO": "Nota o link di approfondimento opzionale.",
+    "MODULO_3_TITOLO": "Titolo della terza tappa del percorso.",
+    "MODULO_3_DEFINIZIONE": "Sintesi in 1 riga della terza tappa.",
+    "MODULO_3_APPROFONDIMENTO": "Nota o link di approfondimento opzionale.",
+    "IMG_SRC": "URL dell'immagine di contesto.",
+    "ALT_IMMAGINE": "Descrizione accessibile dell'immagine (10–15 parole).",
+    "DIDASCALIA_IMMAGINE": "Didascalia che collega l'immagine al tema.",
+    "IMG_CREDITO_URL": "Link alla fonte o ai crediti dell'immagine.",
+    "ISTRUZIONI_COMPITO": "Testo della consegna per il compito guidato.",
+    "STEP_A": "Prima fase dell'attività.",
+    "STEP_B": "Seconda fase dell'attività.",
+    "STEP_C": "Terza fase dell'attività.",
+    "AIUTO_1": "Suggerimento leggero per lo studente.",
+    "AIUTO_2": "Secondo suggerimento opzionale.",
+    "SOLUZIONE_COMMENTATA": "Breve spiegazione della soluzione.",
+    "ISTRUZIONI_QUIZ": "Istruzioni per la sezione quiz.",
+    "CONSIGLIO_STUDIO": "Suggerimento finale dopo il quiz.",
+    "CREDITI_PAGINA": "Crediti o copyright della pagina.",
+    "NOTE_ACCESSIBILITA": "Note su accessibilità o strumenti inclusivi."
+  },
+  "sectionTitles": {
+    "attivazione": "Titolo sezione attivazione",
+    "primer": "Titolo sezione idea chiave",
+    "percorso": "Titolo sezione percorso modulare",
+    "schema": "Titolo sezione mappa",
+    "immagine": "Titolo sezione immagine",
+    "attivita": "Titolo sezione attività",
+    "quiz": "Titolo sezione quiz",
+    "glossario": "Titolo sezione glossario"
+  },
+  "image": {
+    "src": "https://esempio.it/immagine.png",
+    "ALT": "Descrivi l'immagine per chi non la vede.",
+    "caption": "Spiega in 1 riga cosa mostra l'immagine.",
+    "creditUrl": "https://esempio.it/crediti"
+  },
+  "mermaid": "Inserisci qui il diagramma Mermaid (es. flowchart).",
+  "glossario": [
+    {"term": "Termine 1", "def": "Definizione sintetica."},
+    {"term": "Termine 2", "def": "Definizione sintetica."}
+  ],
+  "quiz": [
+    {
+      "q": "Domanda a scelta multipla.",
+      "choices": ["Opzione A", "Opzione B", "Opzione C", "Opzione D"],
+      "correct": 0,
+      "hint": "Suggerimento opzionale.",
+      "explain": "Spiegazione da mostrare dopo la risposta."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a reusable `modello-import.json` template that matches the structure expected by `ingestData`
- update the demo placeholders with the new tooltip key for the template download entry
- wire the settings download control to the template file and document how to use it

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dffd51c7b48326a20e2d8db171e91b