### PR TITLE
Adjust toolbar settings menu anchoring

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,8 @@ a:focus,button:focus,select:focus,input:focus,summary:focus{outline:3px solid va
 }
 .toolbar-settings{position:relative;display:flex;align-items:center}
 .toolbar-settings-menu{
-  position:absolute;top:calc(100% + .4rem);right:0;
+  position:absolute;top:calc(100% + .4rem);left:0;
+  transform:translateX(.2rem);
   background:var(--surface);border:1px solid var(--border);border-radius:12px;
   box-shadow:var(--shadow);padding:.4rem;display:flex;flex-direction:column;gap:.3rem;
   min-width:220px;z-index:20;


### PR DESCRIPTION
## Summary
- anchor the toolbar settings menu from the left edge to keep it within the viewport
- apply a slight horizontal translation to preserve visual spacing after the alignment change

## Testing
- playwright viewport check at 1200px and 600px

------
https://chatgpt.com/codex/tasks/task_e_68e00213c5988326a549a9391e4e10d4