### PR TITLE
Handle descriptive placeholders in templates

### DIFF
--- a/index.html
+++ b/index.html
@@ -1190,7 +1190,10 @@ function announce(msg){ live.textContent=msg; }
   });
 
   // --- Placeholders globali su tutta la pagina ---
-  function makeKeyRegex(key){ return new RegExp('\\['+ key.replace(/[.*+?^${}()|[\\]\\\\]/g,'\\$&') +'\\]','g'); }
+  function makeKeyRegex(key){
+    const escaped=key.replace(/[.*+?^${}()|[\\]\\\\]/g,'\\$&');
+    return new RegExp('\\['+ escaped +'(?::[^\\]]*)?\\]','g');
+  }
   function replaceInString(str,map){ if(typeof str!=='string') return str; let out=str; for(const k of Object.keys(map)){ out=out.replace(makeKeyRegex(k), String(map[k])); } return out; }
 
   function applyGlobalPlaceholders(map){


### PR DESCRIPTION
## Summary
- update the placeholder matching regex to accept descriptive suffixes such as `[KEY: …]`

## Testing
- node placeholder-regex smoke test

------
https://chatgpt.com/codex/tasks/task_e_68e00215fb688326a5b63cf79fb90b30