### PR TITLE
Prevent word instrumentation from splitting placeholder text

### DIFF
--- a/index.html
+++ b/index.html
@@ -577,12 +577,15 @@ document.addEventListener('mousemove',e=>{
    KARAOKE / SINTESI VOCALE (Leggi ≠ Karaoke)
    ========================================================= */
 const EXCLUDE_WRAP='script,style,code,pre,.mermaid,.kw-pop,button,.btn,[role="button"],input,select,textarea,.choice-list,.concept-icon';
+const PLACEHOLDER_REGEX=/\[[A-Z0-9_]+(?::[^\]]*)?\]/;
+const PLACEHOLDER_OPEN_REGEX=/\[[A-Z0-9_]+(?::[^\]]*)?$/;
 function instrumentWords(root){
   const walker=document.createTreeWalker(root,NodeFilter.SHOW_TEXT,null);
   const toWrap=[]; let node;
   while(node=walker.nextNode()){
     const t=node.nodeValue; if(!t || !t.trim()) continue;
     if(node.parentElement.closest(EXCLUDE_WRAP)) continue;
+    if(PLACEHOLDER_REGEX.test(t) || PLACEHOLDER_OPEN_REGEX.test(t)) continue;
     toWrap.push(node);
   }
   toWrap.forEach(n=>{


### PR DESCRIPTION
## Summary
- add placeholder-aware guards to the word instrumentation routine so template tokens stay intact until replacements run

## Testing
- node - <<'NODE'
const PLACEHOLDER_REGEX=/\[[A-Z0-9_]+(?::[^\]]*)?\]/;
const PLACEHOLDER_OPEN_REGEX=/\[[A-Z0-9_]+(?::[^\]]*)?$/;
const samples=[
  '[TITOLO_ARGOMENTO: 3-6 parole]',
  'Benvenuto [NOME_STUDENTE]!',
  'Paragrafo senza segnaposto',
  'Test [INCOMPLETO'
];
for(const text of samples){
  const flagged=PLACEHOLDER_REGEX.test(text)||PLACEHOLDER_OPEN_REGEX.test(text);
  console.log(JSON.stringify(text), '=>', flagged);
}
NODE

------
https://chatgpt.com/codex/tasks/task_e_68e01852ddb88326aff97e13256263fe