### PR TITLE
Ensure exported HTML begins with the doctype

### DIFF
--- a/index.html
+++ b/index.html
@@ -1522,7 +1522,7 @@ function announce(msg){ live.textContent=msg; }
         }
       }
 
-      const html = '<!DOCTYPE html>\\n' + clonedRoot.outerHTML;
+      const html = '<!DOCTYPE html>' + clonedRoot.outerHTML;
       const blob = new Blob([html], {type:'text/html;charset=utf-8'});
       const a=document.createElement('a');
       a.href=URL.createObjectURL(blob);


### PR DESCRIPTION
## Summary
- stop inserting a leading newline before the exported document's DOCTYPE declaration

## Testing
- node -e 'const clonedRoot={outerHTML:"<html></html>"}; const html="<!DOCTYPE html>"+clonedRoot.outerHTML; console.log(html); console.log(html.startsWith("<!DOCTYPE html>"));'

------
https://chatgpt.com/codex/tasks/task_e_68e07924f9f4832695a1fdae490320d6