### PR TITLE
Add CSS rules for simplified mode content toggling

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,6 +93,8 @@ a:focus,button:focus,select:focus,input:focus,summary:focus{outline:3px solid va
 .state-pill{background:var(--accent-weak);border:1px solid var(--border);border-radius:999px;padding:.2rem .5rem;font-size:.85rem}
 
 /* Contenuti */
+.mode-simplified .estesa{display:none}
+body:not(.mode-simplified) .semplificata{display:none}
 .content{max-width:var(--content);margin:0 auto}
 .content h1{
   font-size:1.9rem;margin:.2rem 0 .8rem;display:flex;gap:.6rem;align-items:flex-start;


### PR DESCRIPTION
## Summary
- hide extended content when simplified mode is enabled and show simplified copy only in that mode
- ensure the simplified toggle cleanly switches between rewritten and extended paragraphs

## Testing
- Manual verification in browser


------
https://chatgpt.com/codex/tasks/task_e_68e0eb14cb108326b9e1b80787baee0f