### PR TITLE
Support Unicode placeholder keys

### DIFF
--- a/index.html
+++ b/index.html
@@ -579,8 +579,8 @@ document.addEventListener('mousemove',e=>{
    KARAOKE / SINTESI VOCALE (Leggi ≠ Karaoke)
    ========================================================= */
 const EXCLUDE_WRAP='script,style,code,pre,.mermaid,.kw-pop,button,.btn,[role="button"],input,select,textarea,.choice-list,.concept-icon';
-const PLACEHOLDER_REGEX=/\[[A-Z0-9_]+(?::[^\]]*)?\]/;
-const PLACEHOLDER_OPEN_REGEX=/\[[A-Z0-9_]+(?::[^\]]*)?$/;
+const PLACEHOLDER_REGEX=/\[[\p{L}0-9_]+(?::[^\]]*)?\]/u;
+const PLACEHOLDER_OPEN_REGEX=/\[[\p{L}0-9_]+(?::[^\]]*)?$/u;
 function instrumentWords(root){
   const walker=document.createTreeWalker(root,NodeFilter.SHOW_TEXT,null);
   const toWrap=[]; let node;


### PR DESCRIPTION
## Summary
- allow placeholder matching to include Unicode letters so extended keys stay intact during karaoke instrumentation

## Testing
- manual import of demo-contenuti-emozioni.json to ensure "A che ti servirà" shows personalized text

------
https://chatgpt.com/codex/tasks/task_e_68e0f184d2b883269774c2bca3544e0c