### PR TITLE
Ensure paste import dialog becomes visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -1083,6 +1083,7 @@ function announce(msg){ live.textContent=msg; }
     importDialogLastFocus = triggerBtn || document.activeElement;
     resetImportDialog();
     if(typeof importDialog.showModal==='function'){
+      importDialog.removeAttribute('hidden');
       if(!importDialog.open) importDialog.showModal();
     }else{
       importDialog.setAttribute('open','');


### PR DESCRIPTION
## Summary
- remove the dialog's hidden attribute before invoking showModal so "Incolla contenuti" opens the JSON import form

## Testing
- Manual verification

------
https://chatgpt.com/codex/tasks/task_e_68e3cd6ef7c883268af74bb625e15865