### PR TITLE
Add SVG demo download option with inline SVG rendering support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ## Modello JSON per l'import automatico
 
-1. Apri il menu Impostazioni dell'interfaccia e usa l'azione **Scarica modello JSON** (elemento `#tbDownloadTemplate`) per ottenere `modello-import.json`.
-2. Compila i campi `placeholders`, `sectionTitles`, `image`, `mermaid`, `glossario` e `quiz` con i contenuti della tua lezione. Per il blocco `image` puoi indicare sia file locali sia SVG esterni (anche da URL HTTPS o data URI): l'anteprima verrà ridimensionata per mostrare l'intera immagine.
+1. Apri il menu Impostazioni dell'interfaccia e usa l'azione **Scarica modello JSON** (elemento `#tbDownloadTemplate`) per ottenere `modello-import.json`. Se vuoi un esempio completo con mappa SVG esterna e timeline inline, scegli **Scarica demo SVG** (`#tbDownloadSvgDemo`).
+2. Compila i campi `placeholders`, `sectionTitles`, `image`, `mermaid`, `glossario` e `quiz` con i contenuti della tua lezione. Per il blocco `image` puoi indicare sia file locali sia SVG esterni (anche da URL HTTPS o data URI) e, se serve, inserire codice SVG inline tramite la proprietà `inlineSvg`.
 3. Importa il file completo tramite il pulsante **Importa** oppure incolla il JSON nel dialog dedicato.
 
 Il modello riproduce la struttura attesa dalla funzione `ingestData`, quindi ogni campo verrà applicato automaticamente alla pagina.

--- a/demo-contenuti-emozioni.json
+++ b/demo-contenuti-emozioni.json
@@ -6,6 +6,7 @@
     "TOOLTIP_INCOLLA": "Incolla JSON dagli appunti",
     "TOOLTIP_ESPORTA": "Esporta la pagina in JSON",
     "TOOLTIP_SCARICA_MODELLO": "Scarica il modello di compilazione",
+    "TOOLTIP_SCARICA_DEMO_SVG": "Scarica l'esempio con SVG",
     "TOOLTIP_MODELLO": "Apri elenco campi disponibili",
     "SCOP0_IN_2_RIGHE": "Riconoscere le componenti di un'emozione.\nDistinguere emozione, sentimento e umore.",
     "UTILITÀ_IN_2_RIGHE": "Ti aiuta a interpretare le tue reazioni e a scegliere strategie di autoregolazione efficaci.",

--- a/demo-contenuti-svg.json
+++ b/demo-contenuti-svg.json
@@ -1,0 +1,163 @@
+{
+  "placeholders": {
+    "TITOLO_ARGOMENTO": "Impero romano nel III secolo (2ª liceo)",
+    "TOOLTIP_SETTINGS": "Apri impostazioni rapide",
+    "TOOLTIP_IMPORTA": "Importa contenuti da file JSON",
+    "TOOLTIP_INCOLLA": "Incolla JSON dagli appunti",
+    "TOOLTIP_ESPORTA": "Esporta la pagina in JSON",
+    "TOOLTIP_SCARICA_MODELLO": "Scarica il modello di compilazione",
+    "TOOLTIP_SCARICA_DEMO_SVG": "Scarica l'esempio con SVG",
+    "TOOLTIP_MODELLO": "Apri elenco campi disponibili",
+    "SCOP0_IN_2_RIGHE": "Leggere una carta storica del 230 d.C. per localizzare province e frontiere.\nCollegare eventi politici e militari a cause e conseguenze sulle comunità provinciali.",
+    "UTILITÀ_IN_2_RIGHE": "Ti aiuta a interpretare mappe e timeline della crisi del III secolo.\nCosì puoi spiegare come le decisioni imperiali ricadono sulla vita quotidiana nelle province.",
+    "PREREQUISITI": "Sai leggere una carta tematica e ricordi le fasi principali della Repubblica e del Principato.",
+    "ALT_IMMAGINE": "Carta dell'Impero romano nel 230 d.C. con province e confini evidenziati",
+    "DIDASCALIA_IMMAGINE": "La combinazione di mappa e timeline evidenzia pressioni esterne e risposte interne.",
+    "ISTRUZIONI_BREVI": "Riscalda la memoria con due domande sulla crisi del III secolo.",
+    "DOMANDA_RIATTIVAZIONE_1": "Quale fattore mette in crisi l'equilibrio del III secolo?",
+    "OPZIONE_A": "Frontiere lunghe e attacchi simultanei.",
+    "OPZIONE_B": "Una pace stabile con i Persiani.",
+    "DOMANDA_RIATTIVAZIONE_2": "Nel 238 d.C. il Senato nomina più imperatori per contenere l'anarchia militare.",
+    "FALSO_AMICO_1": "Pensare che l'impero crolli già nel 230: dura altri decenni grazie a riforme e nuove alleanze.",
+    "FALSO_AMICO_2": "Confondere tutte le invasioni con il medioevo: nel III secolo Roma riorganizza l'esercito e mantiene il controllo.",
+    "DEFINIZIONE_OPERATIVA": "La crisi del III secolo intreccia pressioni militari, instabilità politica e riforme di emergenza che trasformano l'impero.",
+    "ESEMPIO_PULITO": "Analizzi la carta del 230 d.C. per spiegare perché l'avanzata persiana costringe Roma a spostare legioni dal Danubio e a rafforzare il limes orientale.",
+    "MODULO_1_TITOLO": "Frontiere sotto pressione",
+    "MODULO_1_DEFINIZIONE": "Nel 230 d.C. l'esercito romano difende confini lunghissimi contro Sasanidi e popolazioni germaniche; leggere la mappa rivela dove si concentrano le legioni e perché alcuni settori restano fragili.",
+    "MODULO_1_ESEMPIO": "Osservando la carta noti che la Mesopotamia è un'area critica: l'avanzata persiana costringe Roma a rinforzare il limes orientale sottraendo truppe al Danubio.",
+    "MODULO_1_CONTROESEMPIO": "Ignorare la distribuzione delle guarnigioni e pensare che ogni provincia riceva lo stesso numero di legioni porta a sottovalutare le aree di crisi.",
+    "MODULO_1_TITOLO_SEMPLIFICATO": "Dove il confine è fragile",
+    "MODULO_1_RISCRITTURA_SEMPLICE": "Confronta la mappa: certe frontiere hanno più soldati perché i nemici sono più pericolosi.",
+    "MODULO_1_APPROFONDIMENTO": "Consulta le iscrizioni del limes siriaco per capire come cambiavano gli stanziamenti delle truppe dopo ogni campagna persiana.",
+    "MODULO_2_TITOLO": "Cambi di potere rapidi",
+    "MODULO_2_DEFINIZIONE": "Tra 235 e 238 d.C. l'esercito proclama più imperatori: collegare timeline e carta mostra come i fronti aperti impediscano una successione stabile.",
+    "MODULO_2_ESEMPIO": "La timeline evidenzia l'ascesa di Massimino Trace nel 235: proveniva dalle frontiere danubiane e spostò il baricentro del potere verso i generali di confine.",
+    "MODULO_2_CONTROESEMPIO": "Se immagini che il Senato controlli da solo la successione, dimentichi che senza il sostegno delle legioni i decreti restano lettera morta.",
+    "MODULO_2_TITOLO_SEMPLIFICATO": "Troppe incoronazioni",
+    "MODULO_2_RISCRITTURA_SEMPLICE": "Nel giro di pochi anni i soldati scelgono nuovi imperatori perché ogni fronte vuole qualcuno che lo difenda subito.",
+    "MODULO_2_APPROFONDIMENTO": "Leggi l'Historia Augusta confrontando Massimino e i Gordiani per vedere come reagiscono le élite provinciali.",
+    "MODULO_3_TITOLO": "Risposte e riforme",
+    "MODULO_3_DEFINIZIONE": "Per arginare la crisi, gli imperatori avviano riforme fiscali e militari; capire l'ordine degli interventi spiega la sopravvivenza dell'impero fino a Diocleziano.",
+    "MODULO_3_ESEMPIO": "Il rafforzamento del comando mobile di Gallieno separa incarichi civili e militari nelle province più esposte, rendendo più rapido l'invio di rinforzi.",
+    "MODULO_3_CONTROESEMPIO": "Pensare che l'impero crolli subito cancella le strategie di adattamento, come la creazione di nuove unità di cavalleria.",
+    "MODULO_3_TITOLO_SEMPLIFICATO": "Come Roma reagisce",
+    "MODULO_3_RISCRITTURA_SEMPLICE": "Gli imperatori sperimentano tasse e generali diversi per tenere insieme territori lontani.",
+    "MODULO_3_APPROFONDIMENTO": "Confronta le riforme di Gallieno e Aureliano usando le schede cronologiche del manuale per cogliere continuità e cambi di passo.",
+    "ISTRUZIONI_COMPITO": "Ordina i passaggi per spiegare a un compagno come leggere mappa e timeline di un evento del III secolo.",
+    "STEP_A": "Individua sulla carta la provincia coinvolta.",
+    "STEP_B": "Collega la data della timeline all'evento militare o politico.",
+    "STEP_C": "Descrivi la conseguenza amministrativa o sociale nella provincia.",
+    "AIUTO_1": "Inizia dalla geografia: un confine minacciato cambia subito la priorità dell'impero.",
+    "AIUTO_2": "Controlla se la timeline segnala un imperatore militare o una riforma economica: cambia la tua spiegazione finale.",
+    "SOLUZIONE_COMMENTATA": "1) Provincia: chiarisci il luogo per dare contesto. 2) Data: collega l'evento alla cronologia per capire chi governa. 3) Conseguenza: spiega come la decisione cambia la vita nella provincia.",
+    "SPIEGAZIONE_SUCCINTA": "Ottimo: hai intrecciato spazio, tempo e decisione politica per raccontare la crisi.",
+    "INDIZIO_DIAGNOSTICO": "Ricontrolla se hai scelto la provincia giusta: senza luogo preciso, la timeline non basta a capire l'effetto.",
+    "ISTRUZIONI_QUIZ": "Rispondi alle domande e usa gli aiuti per collegare carta e timeline.",
+    "CRITERIO_1": "Individua sulle mappe le province coinvolte dagli eventi del III secolo.",
+    "CRITERIO_2": "Collega eventi politici e militari a cause e conseguenze per il territorio.",
+    "CRITERIO_3": "Usa fonti e timeline per spiegare le riforme adottate dagli imperatori.",
+    "VARIANTE_BASE": "Fornisci la carta muta dell'impero e chiedi di etichettare le frontiere più esposte.",
+    "VARIANTE_INTERMEDIA": "Assegna gruppi di lavoro: ognuno ricostruisce una crisi provinciale combinando mappe e cronologie.",
+    "VARIANTE_AVANZATA": "Fai confrontare la crisi del III secolo con quella del V secolo usando dossier di fonti contrapposte.",
+    "TERMINE_1": "Limes",
+    "DEFINIZIONE_1": "Linea di difesa fortificata che separava l'impero da territori non romanizzati.",
+    "TERMINE_2": "Anarchia militare",
+    "DEFINIZIONE_2": "Periodo in cui gli eserciti eleggono e depongono rapidamente gli imperatori.",
+    "TERMINE_3": "Sasanidi",
+    "DEFINIZIONE_3": "Dinastia persiana che sfida Roma nel III secolo con campagne aggressive.",
+    "Q1_TESTO": "Quale fu l'effetto principale dell'Editto di Caracalla del 212 d.C.?",
+    "Q1_OPZ_1": "Concesse la cittadinanza a tutti gli uomini liberi, rafforzando il legame fiscale con le province.",
+    "Q1_OPZ_2": "Divise l'impero in due stati indipendenti.",
+    "Q1_OPZ_3": "Abolì l'esercito permanente romano.",
+    "Q1_OPZ_4": "Trasferì la capitale a Costantinopoli.",
+    "Q1_HINT": "Pensa al rapporto fra cittadinanza e tasse.",
+    "Q1_SPEGAZIONE": "L'estensione della cittadinanza consolida la base fiscale e crea un senso di appartenenza comune utile nelle crisi successive.",
+    "Q2_TESTO": "Perché l'ascesa di Massimino Trace nel 235 d.C. segnala il peso delle frontiere danubiane?",
+    "Q2_OPZ_1": "Perché fu scelto dalle legioni di confine che volevano un comandante energico.",
+    "Q2_OPZ_2": "Perché era un senatore nominato dal Senato romano.",
+    "Q2_OPZ_3": "Perché proveniva dall'aristocrazia africana fedele ai Gordiani.",
+    "Q2_OPZ_4": "Perché abolì subito le campagne militari sul Danubio.",
+    "Q2_HINT": "Guarda la timeline e ricorda dove comandava prima di essere acclamato.",
+    "Q2_SPEGAZIONE": "Massimino era generale sul Danubio: la sua nomina mostra che gli eserciti di frontiera possono imporre il loro capo a tutto l'impero.",
+    "Q3_TESTO": "Quale riforma attribuita a Gallieno migliora la gestione delle province minacciate?",
+    "Q3_OPZ_1": "Separare il comando civile da quello militare creando duces specializzati.",
+    "Q3_OPZ_2": "Abolire la moneta d'argento per usare solo baratto.",
+    "Q3_OPZ_3": "Restituire al Senato il controllo diretto delle legioni.",
+    "Q3_OPZ_4": "Trasformare ogni provincia in municipio autonomo.",
+    "Q3_HINT": "Pensa alle nuove cariche affidate a generali professionisti.",
+    "Q3_SPEGAZIONE": "Gallieno affida il comando militare a ufficiali dedicati, così le province possono reagire più velocemente agli attacchi.",
+    "CONSIGLIO_STUDIO": "Crea una scheda per ogni evento chiave con luogo, data, protagonista e conseguenza: ti aiuta a ripassare incrociando mappa e timeline."
+  },
+  "sectionTitles": {
+    "attivazione": "Domande lampo sulla crisi del III secolo",
+    "primer": "Collega eventi e luoghi",
+    "percorso": "Tre nodi per capire la crisi imperiale",
+    "schema": "Mappa e timeline del III secolo",
+    "immagine": "Cartografia e cronologia a confronto",
+    "attivita": "Allena la lettura delle fonti",
+    "quiz": "Verifica rapida sulla crisi imperiale",
+    "glossario": "Parole chiave del III secolo"
+  },
+  "image": {
+    "src": "https://upload.wikimedia.org/wikipedia/commons/c/c4/230_CE%2C_Europe.svg",
+    "ALT": "Carta dell'impero romano nel 230 d.C. con province colorate e frontiere marcate",
+    "caption": "La carta di Wikimedia Commons e la timeline mostrano come eventi ravvicinati stressano più fronti contemporaneamente.",
+    "creditUrl": "https://commons.wikimedia.org/wiki/File:230_CE,_Europe.svg",
+    "creditLabel": "Wikimedia Commons",
+    "inlineSvg": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 820 220\">\n  <title>Timeline crisi del III secolo</title>\n  <style>\n    text{font-family:'Atkinson Hyperlegible',sans-serif;}\n    .axis{stroke:#1f2328;stroke-width:3;}\n    .marker{stroke:#0b5fff;stroke-width:2;fill:#dfe9ff;}\n    .label{font-size:16px;fill:#1f2328;}\n    .year{font-size:18px;font-weight:700;fill:#0b5fff;}\n  </style>\n  <line class=\"axis\" x1=\"80\" y1=\"170\" x2=\"740\" y2=\"170\"/>\n  <circle class=\"marker\" cx=\"160\" cy=\"170\" r=\"24\"/>\n  <circle class=\"marker\" cx=\"320\" cy=\"170\" r=\"24\"/>\n  <circle class=\"marker\" cx=\"520\" cy=\"170\" r=\"24\"/>\n  <circle class=\"marker\" cx=\"700\" cy=\"170\" r=\"24\"/>\n  <text class=\"year\" x=\"160\" y=\"162\" text-anchor=\"middle\">212</text>\n  <text class=\"label\" x=\"160\" y=\"206\" text-anchor=\"middle\">Editto di Caracalla</text>\n  <text class=\"year\" x=\"320\" y=\"162\" text-anchor=\"middle\">224</text>\n  <text class=\"label\" x=\"320\" y=\"206\" text-anchor=\"middle\">Pressione sasanide</text>\n  <text class=\"year\" x=\"520\" y=\"162\" text-anchor=\"middle\">235</text>\n  <text class=\"label\" x=\"520\" y=\"206\" text-anchor=\"middle\">Ascesa di Massimino</text>\n  <text class=\"year\" x=\"700\" y=\"162\" text-anchor=\"middle\">238</text>\n  <text class=\"label\" x=\"700\" y=\"206\" text-anchor=\"middle\">Crisi dei sei imperatori</text>\n</svg>",
+    "inlineAlt": "Timeline degli eventi principali fra 212 e 238 d.C. con indicazione di editto, invasioni e cambi di imperatore"
+  },
+  "mermaid": "flowchart TD\n  crisi[Crisi del III secolo] --> frontiere[Pressioni ai confini]\n  crisi --> politica[Instabilità politica]\n  crisi --> economia[Bisogno di riforme fiscali]\n  frontiere --> riforme1[Nuove unità mobili]\n  politica --> riforme2[Imperatori militari]\n  economia --> esito[Provvedimenti di Gallieno e Aureliano]\n  riforme1 --> esito\n  riforme2 --> esito\n",
+  "glossario": [
+    {
+      "term": "Limes",
+      "def": "Linea di difesa fortificata che separava l'impero da territori non romanizzati."
+    },
+    {
+      "term": "Anarchia militare",
+      "def": "Periodo in cui gli eserciti eleggono e depongono rapidamente gli imperatori."
+    },
+    {
+      "term": "Sasanidi",
+      "def": "Dinastia persiana che sfida Roma nel III secolo con campagne aggressive."
+    }
+  ],
+  "quiz": [
+    {
+      "q": "Quale fu l'effetto principale dell'Editto di Caracalla del 212 d.C.?",
+      "choices": [
+        "Concesse la cittadinanza a tutti gli uomini liberi, rafforzando il legame fiscale con le province.",
+        "Divise l'impero in due stati indipendenti.",
+        "Abolì l'esercito permanente romano.",
+        "Trasferì la capitale a Costantinopoli."
+      ],
+      "correct": 0,
+      "hint": "Pensa al rapporto fra cittadinanza e tasse.",
+      "explain": "L'estensione della cittadinanza consolida la base fiscale e crea un senso di appartenenza comune utile nelle crisi successive."
+    },
+    {
+      "q": "Perché l'ascesa di Massimino Trace nel 235 d.C. segnala il peso delle frontiere danubiane?",
+      "choices": [
+        "Perché fu scelto dalle legioni di confine che volevano un comandante energico.",
+        "Perché era un senatore nominato dal Senato romano.",
+        "Perché proveniva dall'aristocrazia africana fedele ai Gordiani.",
+        "Perché abolì subito le campagne militari sul Danubio."
+      ],
+      "correct": 0,
+      "hint": "Guarda la timeline e ricorda dove comandava prima di essere acclamato.",
+      "explain": "Massimino era generale sul Danubio: la sua nomina mostra che gli eserciti di frontiera possono imporre il loro capo a tutto l'impero."
+    },
+    {
+      "q": "Quale riforma attribuita a Gallieno migliora la gestione delle province minacciate?",
+      "choices": [
+        "Separare il comando civile da quello militare creando duces specializzati.",
+        "Abolire la moneta d'argento per usare solo baratto.",
+        "Restituire al Senato il controllo diretto delle legioni.",
+        "Trasformare ogni provincia in municipio autonomo."
+      ],
+      "correct": 0,
+      "hint": "Pensa alle nuove cariche affidate a generali professionisti.",
+      "explain": "Gallieno affida il comando militare a ufficiali dedicati, così le province possono reagire più velocemente agli attacchi."
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -111,6 +111,10 @@ body:not(.mode-simplified) .semplificata{display:none}
 #immagine figure:not(.is-svg) img{width:100%;height:auto;max-height:clamp(220px,45vh,360px);object-fit:cover;border-radius:12px}
 #immagine figure.is-svg{background:var(--surface);border-radius:12px;padding:1rem;display:flex;flex-direction:column;gap:.6rem;align-items:stretch}
 #immagine figure.is-svg img{display:block;width:auto;max-width:100%;height:auto;max-height:clamp(220px,55vh,420px);object-fit:contain;border-radius:10px;margin:0 auto}
+#immagine figure[data-has-inline-svg="true"]{gap:1rem}
+#immagine figure [data-role="inline-svg"]{border:1px solid var(--border);border-radius:10px;padding:1rem;background:var(--surface);overflow:auto}
+#immagine figure [data-role="inline-svg"][hidden]{display:none!important}
+#immagine figure [data-role="inline-svg"] svg{width:100%;height:auto}
 #immagine figcaption{width:100%;display:flex;flex-direction:column;gap:.25rem;font-size:.95rem}
 #immagine figcaption [data-role="credit-wrapper"]{display:inline-flex;flex-wrap:wrap;gap:.25rem;align-items:baseline}
 #immagine figcaption a{font-size:.9rem;word-break:break-word}
@@ -220,6 +224,9 @@ body:not(.mode-simplified) .semplificata{display:none}
       <button id="tbDownloadTemplate" class="btn ebtn" role="menuitem" title="[TOOLTIP_SCARICA_MODELLO]">
         <i class="fa-solid fa-download"></i><span>Scarica modello JSON</span>
       </button>
+      <button id="tbDownloadSvgDemo" class="btn ebtn" role="menuitem" title="[TOOLTIP_SCARICA_DEMO_SVG]">
+        <i class="fa-solid fa-vector-square"></i><span>Scarica demo SVG</span>
+      </button>
     </div>
   </div>
   <!-- Tipografia/impaginazione (azioni non persistenti) -->
@@ -283,6 +290,7 @@ body:not(.mode-simplified) .semplificata{display:none}
         <h2><i class="fa-solid fa-image"></i> Immagine di contesto</h2>
         <figure>
           <img src="https://picsum.photos/seed/argomento/1200/600" alt="[ALT_IMMAGINE: descrizione funzionale, 10–15 parole che connettono l’immagine al concetto]">
+          <div data-role="inline-svg" hidden aria-hidden="true"></div>
           <figcaption>
             <span data-role="caption-text">[DIDASCALIA_IMMAGINE: 1 riga che collega l’immagine al nucleo della lezione].</span>
             <span data-role="credit-wrapper">Fonte: <a data-role="credit-link" href="https://picsum.photos/" target="_blank" rel="noopener">https://picsum.photos/</a></span>
@@ -1231,22 +1239,63 @@ function announce(msg){ live.textContent=msg; }
   ensure('applyImage', function(img){
     const fig = document.querySelector('#immagine figure');
     const im = fig?.querySelector('img');
+    const inlineHolder = fig?.querySelector('[data-role="inline-svg"]');
     const cap = fig?.querySelector('figcaption');
     const captionSpan = cap?.querySelector('[data-role="caption-text"]');
     const creditWrapper = cap?.querySelector('[data-role="credit-wrapper"]');
     const creditLink = cap?.querySelector('[data-role="credit-link"]');
 
+    const src = typeof img.src === 'string' ? img.src.trim() : '';
+    const hasSrc = Boolean(src);
+    const altRaw = img.ALT || img.alt;
+    const alt = (typeof altRaw === 'string' ? altRaw : '').trim();
+    const inlineSvg = typeof img.inlineSvg === 'string' ? img.inlineSvg.trim() : '';
+    const hasInline = inlineSvg.length > 0;
+    const inlineAltRaw = typeof img.inlineAlt === 'string' ? img.inlineAlt : '';
+    const inlineAlt = inlineAltRaw.trim();
+
     if(im){
-      if(img.src){ im.src = img.src; }
-      if('loading' in im){ im.loading = img.loading || 'lazy'; }
-      const alt = img.ALT || img.alt;
-      if(typeof alt === 'string' && alt.trim()){
-        im.alt = alt.trim();
-        im.title = alt.trim();
+      if(hasSrc){
+        if(im.src !== src){ im.src = src; }
+        im.hidden = false;
+        im.removeAttribute('aria-hidden');
+      }else{
+        im.hidden = true;
+        im.setAttribute('aria-hidden','true');
+        if(im.hasAttribute('src')) im.removeAttribute('src');
       }
-      const src = (img.src || '').trim();
+      if('loading' in im){ im.loading = img.loading || 'lazy'; }
+      if(alt){
+        im.alt = alt;
+        im.title = alt;
+      }
+    }
+
+    if(inlineHolder){
+      inlineHolder.innerHTML = '';
+      if(hasInline){
+        inlineHolder.innerHTML = inlineSvg;
+        inlineHolder.hidden = false;
+        inlineHolder.removeAttribute('aria-hidden');
+        inlineHolder.setAttribute('role','img');
+        const label = inlineAlt || alt || 'Illustrazione vettoriale';
+        inlineHolder.setAttribute('aria-label', label);
+      }else{
+        inlineHolder.hidden = true;
+        inlineHolder.setAttribute('aria-hidden','true');
+        inlineHolder.removeAttribute('role');
+        inlineHolder.removeAttribute('aria-label');
+      }
+    }
+
+    if(fig){
       const isSvg = /\.svg(\?|#|$)/i.test(src) || /^data:image\/svg\+xml/i.test(src);
-      if(fig){ fig.classList.toggle('is-svg', Boolean(isSvg)); }
+      fig.classList.toggle('is-svg', Boolean(isSvg || hasInline));
+      if(hasInline){
+        fig.dataset.hasInlineSvg = 'true';
+      }else{
+        fig.removeAttribute('data-has-inline-svg');
+      }
     }
 
     if(captionSpan){
@@ -1460,6 +1509,7 @@ function announce(msg){ live.textContent=msg; }
     const pasteBtn=document.getElementById('tbPasteImport');
     const exportBtn=document.getElementById('tbExport');
     const downloadBtn=document.getElementById('tbDownloadTemplate');
+    const svgDemoBtn=document.getElementById('tbDownloadSvgDemo');
     const file=document.getElementById('contentFile') || (function(){ const i=document.createElement('input'); i.type='file'; i.accept='.json,application/json'; i.id='contentFile'; i.hidden=true; document.body.appendChild(i); return i; })();
 
     if(!settingsBtn || !settingsMenu) return;
@@ -1623,6 +1673,9 @@ function announce(msg){ live.textContent=msg; }
       setTimeout(()=>{ URL.revokeObjectURL(a.href); a.remove(); },0);
     });
 
+    if(downloadBtn){ downloadBtn.dataset.bindDownload='true'; }
+    if(svgDemoBtn){ svgDemoBtn.dataset.bindDownload='true'; }
+
     downloadBtn?.addEventListener('click', async (event)=>{
       event.preventDefault();
       closeMenu(true);
@@ -1641,31 +1694,54 @@ function announce(msg){ live.textContent=msg; }
         alert('Impossibile scaricare il modello JSON.');
       }
     });
+
+    svgDemoBtn?.addEventListener('click', async (event)=>{
+      event.preventDefault();
+      closeMenu(true);
+      try{
+        const response=await fetch('demo-contenuti-svg.json', {cache:'no-store'});
+        if(!response.ok) throw new Error('HTTP '+response.status);
+        const blob=await response.blob();
+        const url=URL.createObjectURL(blob);
+        const a=document.createElement('a');
+        a.href=url;
+        a.download='demo-contenuti-svg.json';
+        document.body.appendChild(a); a.click();
+        setTimeout(()=>{ URL.revokeObjectURL(url); a.remove(); },0);
+      }catch(err){
+        console.error('Scarica demo SVG fallito', err);
+        alert('Impossibile scaricare il demo SVG.');
+      }
+    });
   }
 
   document.addEventListener('DOMContentLoaded', ensureToolbarButtons);
-  document.addEventListener('DOMContentLoaded', function(){
-    const trigger=document.getElementById('tbDownloadTemplate');
-    if(!trigger || trigger.dataset.bindDownload==='true') return;
-    trigger.dataset.bindDownload='true';
-    if(!trigger.getAttribute('title')){
-      trigger.setAttribute('title','[TOOLTIP_MODELLO]');
-    }
-    if(trigger.tagName==='A'){
-      trigger.setAttribute('href','modello-import.json');
-      trigger.setAttribute('download','modello-import.json');
-    }else{
-      trigger.addEventListener('click', function(){
-        const link=document.createElement('a');
-        link.href='modello-import.json';
-        link.download='modello-import.json';
-        link.hidden=true;
-        document.body.appendChild(link);
-        link.click();
-        setTimeout(()=>link.remove(),0);
-      });
-    }
-  });
+  function setupStaticDownloadTrigger(id, href, filename, fallbackTitle){
+    document.addEventListener('DOMContentLoaded', function(){
+      const trigger=document.getElementById(id);
+      if(!trigger || trigger.dataset.bindDownload==='true') return;
+      trigger.dataset.bindDownload='true';
+      if(fallbackTitle && !trigger.getAttribute('title')){
+        trigger.setAttribute('title', fallbackTitle);
+      }
+      if(trigger.tagName==='A'){
+        trigger.setAttribute('href', href);
+        trigger.setAttribute('download', filename);
+      }else{
+        trigger.addEventListener('click', function(){
+          const link=document.createElement('a');
+          link.href=href;
+          link.download=filename;
+          link.hidden=true;
+          document.body.appendChild(link);
+          link.click();
+          setTimeout(()=>link.remove(),0);
+        });
+      }
+    });
+  }
+  setupStaticDownloadTrigger('tbDownloadTemplate','modello-import.json','modello-import.json','[TOOLTIP_MODELLO]');
+  setupStaticDownloadTrigger('tbDownloadSvgDemo','demo-contenuti-svg.json','demo-contenuti-svg.json','[TOOLTIP_SCARICA_DEMO_SVG]');
 })();
 </script>
 <!-- ==== /UPGRADE PACK ==== -->

--- a/modello-import.json
+++ b/modello-import.json
@@ -12,6 +12,7 @@
     "TOOLTIP_INCOLLA": "Obbligatorio. Tooltip del pulsante 'Incolla contenuti'. Es.: 'Incolla JSON dagli appunti'.",
     "TOOLTIP_ESPORTA": "Obbligatorio. Tooltip del pulsante 'Esporta'. Es.: 'Scarica il pacchetto JSON della pagina'.",
     "TOOLTIP_SCARICA_MODELLO": "Obbligatorio. Tooltip del pulsante 'Scarica modello JSON'. Es.: 'Ottieni il file di esempio'.",
+    "TOOLTIP_SCARICA_DEMO_SVG": "Facoltativo ma consigliato. Tooltip del pulsante che scarica il demo con esempi SVG. Es.: 'Scarica esempio con grafici vettoriali'.",
     "TOOLTIP_MODELLO": "Obbligatorio. Tooltip dei trigger che richiamano il modello rapido. Es.: 'Mostra i campi disponibili'.",
     "SCOP0_IN_2_RIGHE": "Obbligatorio. Due frasi sugli obiettivi operativi (CEFR B1). Es.: '[OBIETTIVO_1] presentato con parole inclusive. [OBIETTIVO_2] collegato a [CONTESTO_REALE]'.",
     "UTILITÀ_IN_2_RIGHE": "Obbligatorio. Descrive perché serve l'argomento nella vita reale. Es.: 'Comprendere [ARGOMENTO_SPECIFICO] aiuta a [APPLICAZIONE_PRATICA] in [SCENARIO_QUOTIDIANO]'.",
@@ -108,7 +109,9 @@
     "ALT": "Testo alternativo (sovrascritto da ALT_IMMAGINE se presente) che descrive [DETTagLIO_VISIVO].",
     "caption": "Didascalia mostrata sotto l'immagine per collegarla a [SOTTO_TEMA].",
     "creditUrl": "URL con i crediti dell'immagine e riferimenti a [FONTE].",
-    "creditLabel": "Facoltativo. Testo da mostrare per il link di credito al posto dell'URL, es.: 'Wikimedia Commons'."
+    "creditLabel": "Facoltativo. Testo da mostrare per il link di credito al posto dell'URL, es.: 'Wikimedia Commons'.",
+    "inlineSvg": "Facoltativo. Codice SVG inline da mostrare sotto l'immagine (usare stringa con caratteri escapati). Utile per timeline, schemi vettoriali o icone personalizzate.",
+    "inlineAlt": "Facoltativo. Testo alternativo per descrivere l'SVG inline quando presente (altrimenti eredita ALT o usa una descrizione generica)."
   },
   "mermaid": "flowchart TD\n    %% Adatta ogni nodo e collegamento al nuovo argomento prima dell'import\n    start([Definisci ARGOMENTO_SPECIFICO e pubblico]) --> moduli{Mappa i moduli principali}\n    moduli -->|Modulo 1| modulo1[[Sostituisci con titolo del modulo 1]]\n    moduli -->|Modulo 2| modulo2[[Sostituisci con titolo del modulo 2]]\n    moduli -->|Modulo 3| modulo3[[Sostituisci con titolo del modulo 3]]\n    modulo1 --> risorsa1[/Inserisci esempio pratico o caso studio/]\n    modulo2 --> risorsa2[/Aggiungi attività guidata pertinente/]\n    modulo3 --> risorsa3[/Evidenzia collegamenti avanzati/]\n    %% Duplica i nodi se servono ulteriori passaggi o verifiche personalizzate\n",
   "glossario": [


### PR DESCRIPTION
## Summary
- add inline SVG rendering support to the image section and expose a new SVG demo download entry in the settings menu
- provide a complete Roman Empire sample JSON showcasing external and inline SVG assets and update existing sample placeholders
- document the new workflow and extend the import template with inlineSvg guidance

## Testing
- python -m json.tool demo-contenuti-svg.json
- python -m json.tool demo-contenuti-emozioni.json
- python -m json.tool modello-import.json

------
https://chatgpt.com/codex/tasks/task_e_68e3d50faba88326ac75ed132b5719cc