### PR TITLE
Enable rich formatting for intro recap

### DIFF
--- a/demo-contenuti-emozioni.json
+++ b/demo-contenuti-emozioni.json
@@ -86,7 +86,7 @@
     "Q3_HINT": "Combina corpo e cognizione per guidare il comportamento.",
     "Q3_SPEGAZIONE": "Respirazione e ristrutturazione cognitiva riducono la carica emotiva e riportano la mente su pensieri utili. Questa combinazione trasforma l'energia dell'emozione in concentrazione sulla prestazione. Usarla con costanza rende più gestibili interrogazioni, gare o conversazioni difficili.",
     "CONSIGLIO_STUDIO": "Annota per una settimana le tue emozioni con intensità e strategie usate, poi confronta i risultati.",
-    "PRIMA_DI_INIZIARE": "• Conosci il sistema nervoso di base e sai fare esempi di stati emotivi quotidiani.<br>• Hai già provato a descrivere come emozione, pensiero e comportamento si influenzano in situazioni scolastiche."
+    "PRIMA_DI_INIZIARE": "<ul><li><strong>Conosci il sistema nervoso di base</strong> e sai fare esempi di stati emotivi quotidiani.</li><li><strong>Hai già provato a spiegare l'interazione</strong> tra emozione, pensiero e comportamento in situazioni scolastiche.</li></ul>"
   },
   "sectionTitles": {
     "attivazione": "Domande per iniziare",

--- a/index.html
+++ b/index.html
@@ -121,6 +121,11 @@ body:not(.mode-simplified) .semplificata{display:none}
 }
 .content h2{font-size:1.35rem;margin:1.2rem 0 .6rem;display:flex;gap:.5rem;align-items:center}
 .content p{margin:.6rem 0}
+.prestart{margin:.8rem 0 0}
+.prestart-title{margin:.2rem 0 0}
+.prestart-body{margin:.4rem 0 0}
+.prestart-body ul,.prestart-body ol{margin:.4rem 0 0 1.2rem;padding-left:1.1rem}
+.prestart-body li{margin:.3rem 0}
 .card{border:1px solid var(--border);background:var(--card);border-radius:var(--radius);box-shadow:var(--shadow);padding:1rem;margin:1rem 0}
 .notice{border-left:6px solid var(--accent);background:var(--accent-weak);padding:.8rem 1rem;border-radius:6px}
 
@@ -300,7 +305,10 @@ body:not(.mode-simplified) .semplificata{display:none}
         <h1><i class="fa-solid fa-book"></i> [TITOLO_ARGOMENTO: sintetico, concreto, livello scolastico tra parentesi se utile. Evita giochi di parole.]</h1>
         <p class="notice"><strong>Che cosa imparerai.</strong> [SCOP0_IN_2_RIGHE: linguaggio semplice (CEFR B1), 1 frase per riga, 1–3 abilità misurabili.]</p>
         <p class="notice"><strong>A che ti servirà.</strong> [UTILITÀ_IN_2_RIGHE: contesto autentico in cui applicare il concetto.]</p>
-        <p><strong>Prima di iniziare devi sapere che…</strong> [PRIMA_DI_INIZIARE: breve recap narrativo con informazioni di base utili agli studenti.]</p>
+        <div class="prestart">
+          <p class="prestart-title"><strong>Prima di iniziare devi sapere che…</strong></p>
+          <div class="prestart-body">[PRIMA_DI_INIZIARE: breve recap narrativo con informazioni di base utili agli studenti.]</div>
+        </div>
       </header>
 
       <!-- IMMAGINE DI CONTESTO -->


### PR DESCRIPTION
## Summary
- wrap the "Prima di iniziare" recap in a dedicated container so imported HTML keeps its formatting
- add spacing rules for the new container and nested lists to display bullets cleanly
- update the demo JSON to show a bold bullet list example in the intro recap

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e4b2e8328483268075a8a2d402fdb3