### PR TITLE
Reorder percorso section near contextual content

### DIFF
--- a/demo-contenuti-emozioni.json
+++ b/demo-contenuti-emozioni.json
@@ -89,11 +89,11 @@
     "PRIMA_DI_INIZIARE": "• Conosci il sistema nervoso di base e sai fare esempi di stati emotivi quotidiani.<br>• Hai già provato a descrivere come emozione, pensiero e comportamento si influenzano in situazioni scolastiche."
   },
   "sectionTitles": {
+    "immagine": "Immagini per riconoscersi",
+    "percorso": "Tre tappe del percorso",
     "attivazione": "Domande per iniziare",
     "primer": "Idee al volo",
-    "percorso": "Tre tappe del percorso",
     "schema": "Una mappa per orientarti",
-    "immagine": "Immagini per riconoscersi",
     "attivita": "Allenati passo passo",
     "quiz": "Metti alla prova ciò che sai",
     "glossario": "Parole da tenere a mente"

--- a/demo-contenuti-svg.json
+++ b/demo-contenuti-svg.json
@@ -89,11 +89,11 @@
     "CONSIGLIO_STUDIO": "Crea una tabella con date, protagonisti, provvedimenti e conseguenze per visualizzare la sequenza della crisi repubblicana."
   },
   "sectionTitles": {
+    "immagine": "Cartografia della tarda Repubblica",
+    "percorso": "Tre nodi della crisi repubblicana",
     "attivazione": "Domande lampo sulla tarda Repubblica",
     "primer": "Collega eventi e protagonisti",
-    "percorso": "Tre nodi della crisi repubblicana",
     "schema": "Mappa e timeline della crisi",
-    "immagine": "Cartografia della tarda Repubblica",
     "attivita": "Ordina i passaggi chiave",
     "quiz": "Verifica rapida sulla crisi repubblicana",
     "glossario": "Parole chiave della tarda Repubblica"

--- a/index.html
+++ b/index.html
@@ -316,44 +316,6 @@ body:not(.mode-simplified) .semplificata{display:none}
         </figure>
       </section>
 
-      <!-- MICRO-ATTIVAZIONE -->
-      <section id="attivazione" class="card">
-        <h2><i class="fa-solid fa-bolt"></i> Micro-attivazione</h2>
-        <p>[ISTRUZIONI_BREVI: 1 riga per spiegare che seguono 2 stimoli a basso sforzo.]</p>
-        <div class="microqa">
-          <div class="item" data-correct="A">
-            <p>[DOMANDA_RIATTIVAZIONE_1: chiusa a 2 opzioni, 1 riga.]</p>
-            <div class="choices">
-              <button data-choice="A">[OPZIONE_A: corretta]</button>
-              <button data-choice="B">[OPZIONE_B: distrattore tipico]</button>
-            </div>
-            <div class="feedback"></div>
-          </div>
-          <div class="item" data-correct="Vero">
-            <p>[DOMANDA_RIATTIVAZIONE_2: vero/falso, sul nucleo.]</p>
-            <div class="choices">
-              <button data-choice="Vero">Vero</button>
-              <button data-choice="Falso">Falso</button>
-            </div>
-            <div class="feedback"></div>
-          </div>
-        </div>
-        <aside class="card sticky-note" aria-label="Falsi amici">
-          <h3><i class="fa-solid fa-triangle-exclamation"></i> Falsi amici</h3>
-          <ul>
-            <li>[FALSO_AMICO_1: formula comune ma errata + correzione breve.]</li>
-            <li>[FALSO_AMICO_2: misunderstanding atteso + chiarimento operativo.]</li>
-          </ul>
-        </aside>
-      </section>
-
-      <!-- PRIMER -->
-      <section id="primer" class="card">
-        <h2><i class="fa-solid fa-rocket"></i> Primer rapido</h2>
-        <p><i class="fa-solid fa-book-open"></i> <strong>Idea chiave.</strong> [DEFINIZIONE_OPERATIVA].</p>
-        <p><i class="fa-solid fa-image"></i> <strong>Esempio concreto.</strong> [ESEMPIO_PULITO].</p>
-      </section>
-
       <!-- PERCORSO MODULARE -->
       <section id="percorso" class="card">
         <h2><i class="fa-solid fa-layer-group"></i> Percorso modulare</h2>
@@ -393,6 +355,44 @@ body:not(.mode-simplified) .semplificata{display:none}
             <details class="details-lite"><summary>Approfondisci <span class="tag">+</span></summary><p>[MODULO_3_APPROFONDIMENTO].</p></details>
           </div>
         </div>
+      </section>
+
+      <!-- MICRO-ATTIVAZIONE -->
+      <section id="attivazione" class="card">
+        <h2><i class="fa-solid fa-bolt"></i> Micro-attivazione</h2>
+        <p>[ISTRUZIONI_BREVI: 1 riga per spiegare che seguono 2 stimoli a basso sforzo.]</p>
+        <div class="microqa">
+          <div class="item" data-correct="A">
+            <p>[DOMANDA_RIATTIVAZIONE_1: chiusa a 2 opzioni, 1 riga.]</p>
+            <div class="choices">
+              <button data-choice="A">[OPZIONE_A: corretta]</button>
+              <button data-choice="B">[OPZIONE_B: distrattore tipico]</button>
+            </div>
+            <div class="feedback"></div>
+          </div>
+          <div class="item" data-correct="Vero">
+            <p>[DOMANDA_RIATTIVAZIONE_2: vero/falso, sul nucleo.]</p>
+            <div class="choices">
+              <button data-choice="Vero">Vero</button>
+              <button data-choice="Falso">Falso</button>
+            </div>
+            <div class="feedback"></div>
+          </div>
+        </div>
+        <aside class="card sticky-note" aria-label="Falsi amici">
+          <h3><i class="fa-solid fa-triangle-exclamation"></i> Falsi amici</h3>
+          <ul>
+            <li>[FALSO_AMICO_1: formula comune ma errata + correzione breve.]</li>
+            <li>[FALSO_AMICO_2: misunderstanding atteso + chiarimento operativo.]</li>
+          </ul>
+        </aside>
+      </section>
+
+      <!-- PRIMER -->
+      <section id="primer" class="card">
+        <h2><i class="fa-solid fa-rocket"></i> Primer rapido</h2>
+        <p><i class="fa-solid fa-book-open"></i> <strong>Idea chiave.</strong> [DEFINIZIONE_OPERATIVA].</p>
+        <p><i class="fa-solid fa-image"></i> <strong>Esempio concreto.</strong> [ESEMPIO_PULITO].</p>
       </section>
 
       <!-- MAPPA (MERMAID) -->
@@ -492,9 +492,9 @@ flowchart TD
     <ol id="toc">
       <li><a href="#orientamento">Orientamento</a></li>
       <li><a href="#immagine">Immagine di contesto</a></li>
+      <li><a href="#percorso">Percorso modulare</a></li>
       <li><a href="#attivazione">Micro-attivazione</a></li>
       <li><a href="#primer">Primer</a></li>
-      <li><a href="#percorso">Percorso modulare</a></li>
       <li><a href="#schema">Mappa (Mermaid)</a></li>
       <li><a href="#attivita">Attività guidata</a></li>
       <li><a href="#quiz">Verifica formativa</a></li>
@@ -983,7 +983,7 @@ btnShowSolution.addEventListener('click', revealSolution);
 /* =========================================================
    INDICATORE DI PASSO
    ========================================================= */
-const STEPS=['orientamento','immagine','attivazione','primer','percorso','schema','attivita','quiz'];
+const STEPS=['orientamento','immagine','percorso','attivazione','primer','schema','attivita','quiz'];
 let currentStepIndex=0;
 function setStepById(id){
   const i=STEPS.indexOf(id); if(i>=0){ currentStepIndex=i; updateStepperUI(); state.savedStepId=id; save(); }

--- a/modello-import.json
+++ b/modello-import.json
@@ -95,11 +95,11 @@
     "CONSIGLIO_STUDIO": "Obbligatorio. Messaggio finale dopo il quiz. Es.: 'Continua a esercitarti con [ATTIVITÀ_AUTONOMA] legata a [ARGOMENTO_SPECIFICO]'."
   },
   "sectionTitles": {
+    "immagine": "Sostituisci con un titolo originale per la sezione immagine o cartografia che introduce [DETTagLIO_VISIVO].",
+    "percorso": "Sostituisci con un titolo originale per la sezione Percorso modulare centrata su [SOTTO_TEMA].",
     "attivazione": "Sostituisci con un titolo originale per la micro-attivazione collegata a [ARGOMENTO_SPECIFICO] e al gruppo classe.",
     "primer": "Sostituisci con un titolo originale per il Primer rapido dedicato a [CONCETTO_CHIAVE].",
-    "percorso": "Sostituisci con un titolo originale per la sezione Percorso modulare centrata su [SOTTO_TEMA].",
     "schema": "Sostituisci con un titolo originale per la sezione Mappa o diagramma riferita a [ARGOMENTO_SPECIFICO].",
-    "immagine": "Sostituisci con un titolo originale per la sezione immagine contestuale che introduce [DETTagLIO_VISIVO].",
     "attivita": "Sostituisci con un titolo originale per la sezione Attività guidata collegata a [ATTIVITÀ_GUIDATA].",
     "quiz": "Sostituisci con un titolo originale per la sezione Verifica formativa su [CONCETTO_CHIAVE].",
     "glossario": "Sostituisci con un titolo originale per la sezione Glossario dedicato ai termini di [ARGOMENTO_SPECIFICO]."


### PR DESCRIPTION
## Summary
- move the Percorso modulare section directly after the contextual map in the HTML template and update navigation ordering
- align the stepper configuration and section title metadata in the model and demo JSON files with the new section sequence

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e4b4ba706c832688b151e7ed7b595f