### PR TITLE
Improve Italian voice loading reliability

### DIFF
--- a/index.html
+++ b/index.html
@@ -703,7 +703,32 @@ function prepareSpeechText(text){
 }
 
 /* Precarica voci privilegiando automaticamente le migliori voci italiane (online se presenti). */
-function waitForVoices(ms=2500){return new Promise(res=>{let t=0;const s=100;const id=setInterval(()=>{if(synth.getVoices().length||t>=ms){clearInterval(id);res(synth.getVoices());}t+=s;},s);});}
+function waitForVoices({timeout=7000,settle=300}={}){
+  return new Promise(res=>{
+    const step=120;
+    let elapsed=0;
+    let stableFor=0;
+    let lastCount=-1;
+    const finish=list=>{clearInterval(id); res(list);};
+    const check=()=>{
+      const list=synth.getVoices();
+      const count=list.length;
+      if(count){
+        if(count!==lastCount){
+          lastCount=count;
+          stableFor=0;
+        }else{
+          stableFor+=step;
+          if(stableFor>=settle) return finish(list);
+        }
+      }
+      elapsed+=step;
+      if(elapsed>=timeout) return finish(list);
+    };
+    const id=setInterval(check,step);
+    check();
+  });
+}
 // Ordina le voci italiane dando priorità a quelle online di qualità elevata.
 function scoreVoice(v){
   const name=`${v.name} ${v.voiceURI}`.toLowerCase();
@@ -718,12 +743,49 @@ function scoreVoice(v){
   if(/\bit-?it\b/.test(v.lang.toLowerCase())) score+=20;
   return score;
 }
-async function setupVoices(){
-  voices=synth.getVoices(); if(!voices.length) voices=await waitForVoices();
+const ITALIAN_VOICE_HINTS=[
+  'diego','elisa','elsa','isabella','valentina','gianni','andrea','bianca','lucia','luca',
+  'chiara','caterina','giorgio','silvia','paolo','federica','carla','matteo','marco','serena',
+  'giulia','noemi','riccardo','pierluigi','filippo','nicolo','nicolò','marta','sara'
+];
+function isItalianVoice(v){
+  const rawLang=(v.lang||'').toLowerCase();
+  const lang=rawLang.replace(/_/g,'-');
+  if(lang.startsWith('it') || lang.includes('ital')) return true;
+  const descriptor=`${v.name||''} ${v.voiceURI||''}`.toLowerCase();
+  if(/italiano|italian/.test(descriptor)) return true;
+  if(/\bitaly\b|\bitalia\b/.test(descriptor)) return true;
+  if(/\bit[-_]?it\b/.test(descriptor) || /\bit[-_]?ch\b/.test(descriptor)) return true;
+  return ITALIAN_VOICE_HINTS.some(hint=>descriptor.includes(hint) && !/(^|\b)(es|pt|fr|en|de)[-_]/.test(lang));
+}
+let voiceRetryTimer=null, voiceRetryCount=0, lastVoiceSignature='';
+const clearVoiceRetry=()=>{if(voiceRetryTimer){clearTimeout(voiceRetryTimer);voiceRetryTimer=null;}voiceRetryCount=0;};
+const scheduleVoiceRetry=()=>{
+  if(voiceRetryTimer||voiceRetryCount>=3) return;
+  voiceRetryCount++;
+  voiceRetryTimer=setTimeout(()=>{voiceRetryTimer=null; setupVoices(true);}, 900*voiceRetryCount);
+};
+const signatureFor=list=>list.map(v=>`${v.voiceURI||''}::${v.name||''}::${v.lang||''}`).join('|');
+async function setupVoices(force=false){
+  let allVoices=synth.getVoices();
+  if(!allVoices.length || force) allVoices=await waitForVoices();
+  const italianList=Array.isArray(allVoices)?allVoices.filter(isItalianVoice):[];
+  const signature=signatureFor(italianList);
+  if(!force && signature && signature===lastVoiceSignature) return;
+  lastVoiceSignature=signature;
+  voices=italianList;
   const sel=$('#voiceSel'); sel.innerHTML='';
-  const itVoices=voices.filter(v=>/it-|ital/i.test(v.lang));
-  const list=itVoices.length?itVoices:voices;
-  const sorted=list.slice().sort((a,b)=>{
+  if(!voices.length){
+    const o=document.createElement('option');
+    o.textContent='Nessuna voce italiana disponibile';
+    o.disabled=true; o.selected=true; o.value='';
+    sel.appendChild(o);
+    sel.disabled=true;
+    if(state.voiceURI){ state.voiceURI=''; save(); }
+    return;
+  }
+  sel.disabled=false;
+  const sorted=voices.slice().sort((a,b)=>{
     const diff=scoreVoice(b)-scoreVoice(a);
     return diff!==0?diff:(a.name.localeCompare(b.name));
   });
@@ -740,11 +802,19 @@ async function setupVoices(){
   });
   const keep = voices.find(v=>v.voiceURI===state.voiceURI);
   const preferred=keep || sorted[0];
-  sel.value = (preferred?.voiceURI) || sel.value;
+  sel.value = (preferred?.voiceURI) || '';
   if(!keep && preferred){ state.voiceURI=preferred.voiceURI; save(); }
   else if(!state.voiceURI){ state.voiceURI=sel.value; save(); }
+  if(voices.some(v=>!v.localService)) clearVoiceRetry();
+  else if(voices.length) scheduleVoiceRetry();
+  else clearVoiceRetry();
 }
-if('speechSynthesis' in window){ setupVoices(); speechSynthesis.onvoiceschanged=setupVoices; }
+if('speechSynthesis' in window){
+  const handler=()=>setupVoices(true);
+  if(speechSynthesis.addEventListener) speechSynthesis.addEventListener('voiceschanged', handler);
+  else speechSynthesis.onvoiceschanged=handler;
+  setupVoices();
+}
 const getSelVoice=()=>voices.find(v=>v.voiceURI===$('#voiceSel').value)||null;
 
 let karaokeBundle=null, afterSpeak=null;

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.5.2/css/all.min.css"/>
 <link href="https://fonts.googleapis.com/css2?family=Atkinson+Hyperlegible:wght@400;700&family=Lexend:wght@400;600;700&family=Readex+Pro:wght@400;600;700&display=swap" rel="stylesheet">
 <script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>
+<script src="js/italian-voices.js"></script>
 
 <style>
 /* =========================================================
@@ -642,6 +643,12 @@ function instrumentWords(root){
 function instrumentSubtree(el){ instrumentWords(el); annotateKeywordWords(el); }
 
 const synth=window.speechSynthesis; let voices=[]; let utter=null; let paused=false;
+const voiceUtils=window.ItalianVoices||globalThis.ItalianVoices||{};
+const scoreVoice=voiceUtils.scoreVoice||(v=>{const lang=(v?.lang||'').toLowerCase();return lang.startsWith('it')?10:0;});
+const isItalianVoice=voiceUtils.isItalianVoice||(v=>(v?.lang||'').toLowerCase().startsWith('it'));
+const signatureFor=voiceUtils.signatureFor||(list=>Array.isArray(list)?list.map(v=>`${v.voiceURI||''}::${v.name||''}::${v.lang||''}`).join('|'):'' );
+const compareVoices=voiceUtils.compareVoices||((a,b)=>{const diff=scoreVoice(b)-scoreVoice(a);return diff!==0?diff:String(a?.name||'').localeCompare(String(b?.name||''));});
+const filterItalianVoices=voiceUtils.filterItalianVoices||(list=>Array.isArray(list)?list.filter(isItalianVoice):[]);
 const LETTER_RE=/[A-Za-zÀ-ÖØ-öø-ÿ]/;
 const SPEECH_RULES=[
   (text, index)=>{
@@ -703,7 +710,7 @@ function prepareSpeechText(text){
 }
 
 /* Precarica voci privilegiando automaticamente le migliori voci italiane (online se presenti). */
-function waitForVoices({timeout=7000,settle=300}={}){
+function waitForVoices({timeout=12000,settle=500}={}){
   return new Promise(res=>{
     const step=120;
     let elapsed=0;
@@ -729,53 +736,19 @@ function waitForVoices({timeout=7000,settle=300}={}){
     check();
   });
 }
-// Ordina le voci italiane dando priorità a quelle online di qualità elevata.
-function scoreVoice(v){
-  const name=`${v.name} ${v.voiceURI}`.toLowerCase();
-  let score=0;
-  if(/it-|ital/.test(v.lang)) score+=120; else score-=120;
-  if(/online/.test(name) || !v.localService) score+=60;
-  if(/natural|neural/.test(name)) score+=25;
-  if(/microsoft (lucia|isabella|elsa|valentina|andrea|gianni|bianca)/.test(name)) score+=35;
-  if(/google italiano/.test(name)) score+=40;
-  if(/diego/.test(name)) score+=30;
-  if(/(alice|chiara|caterina|luca|paolo|giorgio|silvia|carla|federica)/.test(name)) score+=15;
-  if(/\bit-?it\b/.test(v.lang.toLowerCase())) score+=20;
-  return score;
-}
-const ITALIAN_VOICE_HINTS=[
-  'diego','elisa','elsa','isabella','valentina','gianni','andrea','bianca','lucia','luca',
-  'chiara','caterina','giorgio','silvia','paolo','federica','carla','matteo','marco','serena',
-  'giulia','noemi','riccardo','pierluigi','filippo','nicolo','nicolò','marta','sara'
-];
-function isItalianVoice(v){
-  const rawLang=(v.lang||'').toLowerCase();
-  const lang=rawLang.replace(/_/g,'-');
-  if(lang.startsWith('it') || lang.includes('ital')) return true;
-  const descriptor=`${v.name||''} ${v.voiceURI||''}`.toLowerCase();
-  if(/italiano|italian/.test(descriptor)) return true;
-  if(/\bitaly\b|\bitalia\b/.test(descriptor)) return true;
-  if(/\bit[-_]?it\b/.test(descriptor) || /\bit[-_]?ch\b/.test(descriptor)) return true;
-  return ITALIAN_VOICE_HINTS.some(hint=>descriptor.includes(hint) && !/(^|\b)(es|pt|fr|en|de)[-_]/.test(lang));
-}
 let voiceRetryTimer=null, voiceRetryCount=0, lastVoiceSignature='';
 const clearVoiceRetry=()=>{if(voiceRetryTimer){clearTimeout(voiceRetryTimer);voiceRetryTimer=null;}voiceRetryCount=0;};
 const scheduleVoiceRetry=()=>{
-  if(voiceRetryTimer||voiceRetryCount>=3) return;
+  const RETRY_DELAYS=[1200,2600,4200,6200,9200,12500];
+  if(voiceRetryTimer||voiceRetryCount>=RETRY_DELAYS.length) return;
+  const delay=RETRY_DELAYS[voiceRetryCount];
   voiceRetryCount++;
-  voiceRetryTimer=setTimeout(()=>{voiceRetryTimer=null; setupVoices(true);}, 900*voiceRetryCount);
+  voiceRetryTimer=setTimeout(()=>{voiceRetryTimer=null; setupVoices(true);}, delay);
 };
-const signatureFor=list=>list.map(v=>[
-  v.voiceURI||'',
-  v.name||'',
-  v.lang||'',
-  String(!!v.localService),
-  String(!!v.default)
-].join('::')).join('|');
 async function setupVoices(force=false){
   let allVoices=synth.getVoices();
   if(!allVoices.length || force) allVoices=await waitForVoices();
-  const italianList=Array.isArray(allVoices)?allVoices.filter(isItalianVoice):[];
+  const italianList=filterItalianVoices(allVoices);
   const signature=signatureFor(italianList);
   if(!force && signature && signature===lastVoiceSignature) return;
   lastVoiceSignature=signature;
@@ -791,10 +764,7 @@ async function setupVoices(force=false){
     return;
   }
   sel.disabled=false;
-  const sorted=voices.slice().sort((a,b)=>{
-    const diff=scoreVoice(b)-scoreVoice(a);
-    return diff!==0?diff:(a.name.localeCompare(b.name));
-  });
+  const sorted=voices.slice().sort(compareVoices);
   const topScore=sorted.length?scoreVoice(sorted[0]):0;
   sorted.forEach(v=>{
     const o=document.createElement('option');

--- a/index.html
+++ b/index.html
@@ -765,7 +765,13 @@ const scheduleVoiceRetry=()=>{
   voiceRetryCount++;
   voiceRetryTimer=setTimeout(()=>{voiceRetryTimer=null; setupVoices(true);}, 900*voiceRetryCount);
 };
-const signatureFor=list=>list.map(v=>`${v.voiceURI||''}::${v.name||''}::${v.lang||''}`).join('|');
+const signatureFor=list=>list.map(v=>[
+  v.voiceURI||'',
+  v.name||'',
+  v.lang||'',
+  String(!!v.localService),
+  String(!!v.default)
+].join('::')).join('|');
 async function setupVoices(force=false){
   let allVoices=synth.getVoices();
   if(!allVoices.length || force) allVoices=await waitForVoices();

--- a/js/italian-voices.js
+++ b/js/italian-voices.js
@@ -1,0 +1,107 @@
+(function(root,factory){
+  const utils=factory();
+  if(typeof module==='object' && module.exports){ module.exports=utils; }
+  if(root){ root.ItalianVoices=utils; }
+})(typeof globalThis!=='undefined'?globalThis:typeof window!=='undefined'?window:this,function(){
+  const ITALIAN_VOICE_HINTS=[
+    'alice','andrea','bianca','caterina','chiara','diego','elena','elisa','elsa','federica','filippo',
+    'gianni','giorgio','giulia','isabella','lucia','luca','marco','marta','matteo','noemi','paolo',
+    'riccardo','serena','silvia','valentina','carla','susanna','nicol\u00f2','nicolo','pierluigi'
+  ];
+  const ITALIAN_WORD_PATTERN=/\bital(?:ian|iano|iani|iana|ia|y)\b/;
+  const ITALIAN_COUNTRY_PATTERN=/\bital(?:y|ia)\b/;
+  const IT_CODE_PATTERN=/\bit[-_]?it\b/;
+  const IT_CH_PATTERN=/\bit[-_]?ch\b/;
+
+  const lower=str=>String(str||'').toLowerCase();
+  const normalizeLang=lang=>lower(lang).replace(/_/g,'-');
+
+  const hasExplicitItalianMarker=voice=>{
+    const descriptor=lower(`${voice?.name||''} ${voice?.voiceURI||''}`);
+    const lang=normalizeLang(voice?.lang||'');
+    const uri=lower(voice?.voiceURI||'');
+    if(!descriptor && !lang && !uri) return false;
+    if(lang.startsWith('it') || lang.includes('ital')) return true;
+    if(ITALIAN_WORD_PATTERN.test(lang)) return true;
+    if(ITALIAN_WORD_PATTERN.test(descriptor) || ITALIAN_COUNTRY_PATTERN.test(descriptor)) return true;
+    if(IT_CODE_PATTERN.test(descriptor) || IT_CH_PATTERN.test(descriptor)) return true;
+    if(ITALIAN_WORD_PATTERN.test(uri) || ITALIAN_COUNTRY_PATTERN.test(uri)) return true;
+    if(IT_CODE_PATTERN.test(uri) || IT_CH_PATTERN.test(uri)) return true;
+    return false;
+  };
+
+  function isItalianVoice(voice){
+    if(!voice) return false;
+    const descriptor=lower(`${voice.name||''} ${voice.voiceURI||''}`);
+    const lang=normalizeLang(voice.lang||'');
+    if(hasExplicitItalianMarker(voice)) return true;
+    const hintMatched=ITALIAN_VOICE_HINTS.some(hint=>descriptor.includes(hint));
+    if(!hintMatched) return false;
+    const uri=lower(voice.voiceURI||'');
+    if(ITALIAN_WORD_PATTERN.test(descriptor) || ITALIAN_COUNTRY_PATTERN.test(descriptor)) return true;
+    if(IT_CODE_PATTERN.test(descriptor) || IT_CH_PATTERN.test(descriptor)) return true;
+    if(ITALIAN_WORD_PATTERN.test(uri) || ITALIAN_COUNTRY_PATTERN.test(uri) || IT_CODE_PATTERN.test(uri) || IT_CH_PATTERN.test(uri)) return true;
+    if(lang.startsWith('it') || lang.includes('ital')) return true;
+    if(!lang) return true;
+    if(/^(es|pt|fr|de|en|ca|br|mx|us|uk)([-_]|$)/.test(lang)) return false;
+    return true;
+  }
+
+  function scoreVoice(voice){
+    const name=lower(`${voice?.name||''} ${voice?.voiceURI||''}`);
+    let score=0;
+    const lang=normalizeLang(voice?.lang||'');
+    if(lang.startsWith('it') || lang.includes('ital')) score+=120; else score-=120;
+    if(/online/.test(name) || voice?.localService===false) score+=60;
+    if(/natural|neural/.test(name)) score+=25;
+    if(/microsoft (lucia|isabella|elsa|valentina|andrea|gianni|bianca|diego)/.test(name)) score+=35;
+    if(/google (italiano|italian)/.test(name)) score+=40;
+    if(/diego/.test(name)) score+=30;
+    if(/(alice|chiara|caterina|luca|paolo|giorgio|silvia|carla|federica|elena|serena)/.test(name)) score+=15;
+    if(voice?.localService===false) score+=10;
+    if(/\bit[-_]?it\b/.test(lang)) score+=20;
+    return score;
+  }
+
+  function compareVoices(a,b){
+    const diff=scoreVoice(b)-scoreVoice(a);
+    if(diff!==0) return diff;
+    const nameA=String(a?.name||'');
+    const nameB=String(b?.name||'');
+    return nameA.localeCompare(nameB);
+  }
+
+  function signatureFor(list){
+    if(!Array.isArray(list)) return '';
+    return list.map(v=>[
+      v?.voiceURI||'',
+      v?.name||'',
+      v?.lang||'',
+      String(!!v?.localService),
+      String(!!v?.default)
+    ].join('::')).join('|');
+  }
+
+  function filterItalianVoices(list){
+    if(!Array.isArray(list)) return [];
+    const seen=new Set();
+    const result=[];
+    for(const voice of list){
+      if(!isItalianVoice(voice)) continue;
+      const key=`${voice.voiceURI||''}::${voice.name||''}`;
+      if(seen.has(key)) continue;
+      seen.add(key);
+      result.push(voice);
+    }
+    return result;
+  }
+
+  return {
+    ITALIAN_VOICE_HINTS,
+    isItalianVoice,
+    scoreVoice,
+    compareVoices,
+    signatureFor,
+    filterItalianVoices
+  };
+});

--- a/tests/italian-voices.test.cjs
+++ b/tests/italian-voices.test.cjs
@@ -1,0 +1,51 @@
+const test=require('node:test');
+const assert=require('node:assert/strict');
+const {
+  isItalianVoice,
+  scoreVoice,
+  compareVoices,
+  signatureFor,
+  filterItalianVoices
+}=require('../js/italian-voices.js');
+
+test('detects Italian voices from language tag',()=>{
+  assert.ok(isItalianVoice({name:'Any', voiceURI:'uri', lang:'it-IT'}));
+  assert.ok(isItalianVoice({name:'Voce italiana', voiceURI:'uri', lang:'it_CH'}));
+});
+
+test('detects Italian voices from descriptor hints even with empty lang',()=>{
+  assert.ok(isItalianVoice({name:'Microsoft Diego Online (Natural)', voiceURI:'MSTTS_V110_itIT_DiegoM', lang:''}));
+  assert.ok(isItalianVoice({name:'Elisa', voiceURI:'google/it-it-elisa', lang:''}));
+});
+
+test('excludes non-Italian voices with similar names',()=>{
+  assert.ok(!isItalianVoice({name:'Microsoft Diego Online (Natural)', voiceURI:'MSTTS_V110_esES_DiegoM', lang:'es-ES'}));
+  assert.ok(!isItalianVoice({name:'Elisa', voiceURI:'google/es-es-elisa', lang:'es-ES'}));
+});
+
+test('filterItalianVoices returns unique italian voices only',()=>{
+  const voices=[
+    {name:'Diego', voiceURI:'uri:it-diego', lang:'it-IT'},
+    {name:'Diego', voiceURI:'uri:it-diego', lang:'it-IT'},
+    {name:'Maria', voiceURI:'uri:es-maria', lang:'es-ES'}
+  ];
+  const filtered=filterItalianVoices(voices);
+  assert.equal(filtered.length,1);
+  assert.equal(filtered[0].name,'Diego');
+});
+
+test('compareVoices prefers online neural options',()=>{
+  const local={name:'Lucia', voiceURI:'local', lang:'it-IT', localService:true};
+  const online={name:'Lucia Online Neural', voiceURI:'online', lang:'it-IT', localService:false};
+  assert.ok(compareVoices(online,local)<0, 'online voice should sort before local');
+});
+
+test('signatureFor tracks relevant fields',()=>{
+  const voices=[
+    {name:'Lucia', voiceURI:'uri:lucia', lang:'it-IT', localService:true, default:true},
+    {name:'Diego', voiceURI:'uri:diego', lang:'it-IT', localService:false, default:false}
+  ];
+  const signature=signatureFor(voices);
+  assert.match(signature,/uri:lucia::Lucia::it-IT::true::true/);
+  assert.match(signature,/uri:diego::Diego::it-IT::false::false/);
+});


### PR DESCRIPTION
## Summary
- wait for the speech synthesis voice list to stabilise longer and retry when only local Italian voices are available
- cache the current Italian voice signature and refresh through the `voiceschanged` event listener to catch newly loaded online voices
- broaden the descriptor match so entries mentioning Italy/Italia are treated as Italian voices

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e80b4ff2c88326beec7d01e46248b4