### PR TITLE
Ensure voice list refreshes when new voices become available

### DIFF
--- a/index.html
+++ b/index.html
@@ -773,7 +773,14 @@ async function setupVoices(){
   if(!keep && preferred){ state.voiceURI=preferred.voiceURI; save(); }
   else if(!state.voiceURI){ state.voiceURI=sel.value; save(); }
 }
-if('speechSynthesis' in window){ setupVoices(); speechSynthesis.onvoiceschanged=setupVoices; }
+if('speechSynthesis' in window){
+  setupVoices();
+  if(typeof speechSynthesis.addEventListener==='function'){
+    speechSynthesis.addEventListener('voiceschanged', setupVoices);
+  }else{
+    speechSynthesis.onvoiceschanged=setupVoices;
+  }
+}
 const getSelVoice=()=>voices.find(v=>v.voiceURI===$('#voiceSel').value)||null;
 
 let karaokeBundle=null, afterSpeak=null;


### PR DESCRIPTION
## Summary
- update the speech synthesis setup to listen for `voiceschanged` using addEventListener when supported
- fall back to the previous handler assignment for browsers that do not support event listeners

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e816e2bc4883269ac8a05c5ecf4f83