### PR TITLE
Enable Italian voices even when only local options exist

### DIFF
--- a/index.html
+++ b/index.html
@@ -746,7 +746,7 @@ function isDiegoVoice(v){
 async function setupVoices(){
   let allVoices=synth.getVoices(); if(!allVoices.length) allVoices=await waitForVoices();
   voices=Array.isArray(allVoices)
-    ? allVoices.filter(v=>isDiegoVoice(v) || (!v.localService && isItalianVoice(v)))
+    ? allVoices.filter(v=>isItalianVoice(v))
     : [];
   const sel=$('#voiceSel'); sel.innerHTML='';
   if(!voices.length){


### PR DESCRIPTION
## Summary
- include all Italian speech synthesis voices so local options remain available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e89396dfd08326b5a77a879f3c7d76