### PR TITLE
Allow configuring section icons via JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,12 @@
 ## Modello JSON per l'import automatico
 
 1. Apri il menu Impostazioni dell'interfaccia e usa l'azione **Scarica modello JSON** (elemento `#tbDownloadTemplate`) per ottenere `modello-import.json`. Se vuoi un esempio completo con mappa SVG esterna, timeline e testi estesi, scegli **Scarica JSON di esempio** (`#tbDownloadExample`).
-2. Compila i campi `placeholders`, `sectionTitles`, `image`, `mermaid`, `glossario` e `quiz` con i contenuti della tua lezione. Per il blocco `image` puoi indicare sia file locali sia SVG esterni (anche da URL HTTPS o data URI) e, se serve, inserire codice SVG inline tramite la proprietà `inlineSvg`.
+2. Compila i campi `placeholders`, `sectionTitles`, `sectionIcons`, `image`, `mermaid`, `glossario` e `quiz` con i contenuti della tua lezione. Per il blocco `image` puoi indicare sia file locali sia SVG esterni (anche da URL HTTPS o data URI) e, se serve, inserire codice SVG inline tramite la proprietà `inlineSvg`.
 3. Importa il file completo tramite il pulsante **Importa** oppure incolla il JSON nel dialog dedicato.
 
 Il modello riproduce la struttura attesa dalla funzione `ingestData`, quindi ogni campo verrà applicato automaticamente alla pagina.
+
+La mappa `sectionIcons` permette di scegliere le icone Font Awesome da mostrare in ogni intestazione (inclusi i tre moduli del percorso). Puoi assegnare classi come `fa-solid fa-heart` oppure indicare, per la sezione `percorso`, anche l'array `modules` per sostituire le icone dei singoli step con simboli legati al tuo argomento.
 
 ## Suggerimenti su encoding e HTML inline
 

--- a/demo-contenuti-emozioni.json
+++ b/demo-contenuti-emozioni.json
@@ -99,6 +99,25 @@
     "quiz": "Metti alla prova ciò che sai",
     "glossario": "Parole da tenere a mente"
   },
+  "sectionIcons": {
+    "orientamento": "fa-solid fa-heart-pulse",
+    "immagine": "fa-solid fa-photo-film",
+    "percorso": {
+      "icon": "fa-solid fa-diagram-project",
+      "modules": [
+        "fa-solid fa-heart",
+        "fa-solid fa-brain",
+        "fa-solid fa-hands-holding"
+      ]
+    },
+    "attivazione": "fa-solid fa-fire",
+    "primer": "fa-solid fa-lightbulb",
+    "schema": "fa-solid fa-network-wired",
+    "attivita": "fa-solid fa-people-group",
+    "quiz": "fa-solid fa-circle-question",
+    "docente": "fa-solid fa-user-graduate",
+    "glossario": "fa-solid fa-book-bookmark"
+  },
   "image": {
     "src": "https://mastercoachitalia.com/wp-content/uploads/2023/08/ruota-emozioni.png",
     "ALT": "Ruota delle emozioni con famiglie e intensità",

--- a/demo-contenuti-svg.json
+++ b/demo-contenuti-svg.json
@@ -99,6 +99,25 @@
     "quiz": "Verifica rapida sulla crisi repubblicana",
     "glossario": "Parole chiave della tarda Repubblica"
   },
+  "sectionIcons": {
+    "orientamento": "fa-solid fa-landmark",
+    "immagine": "fa-solid fa-map",
+    "percorso": {
+      "icon": "fa-solid fa-route",
+      "modules": [
+        "fa-solid fa-scale-balanced",
+        "fa-solid fa-shield-halved",
+        "fa-solid fa-crown"
+      ]
+    },
+    "attivazione": "fa-solid fa-flag",
+    "primer": "fa-solid fa-scroll",
+    "schema": "fa-solid fa-timeline",
+    "attivita": "fa-solid fa-list-check",
+    "quiz": "fa-solid fa-circle-question",
+    "docente": "fa-solid fa-user-tie",
+    "glossario": "fa-solid fa-book-open"
+  },
   "image": {
     "src": "https://upload.wikimedia.org/wikipedia/commons/5/58/Mondo_romano_nel_56_aC_al_tempo_del_primo_triumvirato.png",
     "ALT": "Mappa del mondo romano nel 56 a.C. al tempo del Primo Triumvirato",

--- a/demo-crisi-repubblicana.json
+++ b/demo-crisi-repubblicana.json
@@ -102,6 +102,25 @@
     "quiz": "Verifica rapida sulla crisi",
     "glossario": "Lessico della tarda Repubblica"
   },
+  "sectionIcons": {
+    "orientamento": "fa-solid fa-landmark",
+    "immagine": "fa-solid fa-map",
+    "percorso": {
+      "icon": "fa-solid fa-route",
+      "modules": [
+        "fa-solid fa-scale-balanced",
+        "fa-solid fa-shield-halved",
+        "fa-solid fa-crown"
+      ]
+    },
+    "attivazione": "fa-solid fa-flag",
+    "primer": "fa-solid fa-scroll",
+    "schema": "fa-solid fa-timeline",
+    "attivita": "fa-solid fa-list-check",
+    "quiz": "fa-solid fa-circle-question",
+    "docente": "fa-solid fa-user-tie",
+    "glossario": "fa-solid fa-book-open"
+  },
   "image": {
     "src": "https://upload.wikimedia.org/wikipedia/commons/5/58/Mondo_romano_nel_56_aC_al_tempo_del_primo_triumvirato.png",
     "ALT": "Carta del mondo romano nel 56 a.C. con province e alleati",

--- a/index.html
+++ b/index.html
@@ -2521,6 +2521,104 @@ document.addEventListener('click',e=>{
   ensure('buildGlossary', NOP);
   ensure('applyPrefs', NOP);
   ensure('renderQuizList', NOP);
+  ensure('applySectionIcons', function(icons){
+    if(!icons || typeof icons!=='object') return;
+
+    const headingMap={
+      orientamento:'#orientamento>h1',
+      immagine:'#immagine>h2',
+      percorso:'#percorso>h2',
+      attivazione:'#attivazione>h2',
+      primer:'#primer>h2',
+      schema:'#schema>h2',
+      attivita:'#attivita>h2',
+      quiz:'#quiz>h2',
+      glossario:'#glossario>h2',
+      docente:'#docente>h2'
+    };
+
+    const sanitizeClasses=value=>{
+      if(typeof value!=='string') return '';
+      return value
+        .split(/\s+/)
+        .map(token=>token.trim())
+        .filter(token=>/^fa[a-z0-9-]*$/i.test(token))
+        .join(' ')
+        .trim();
+    };
+
+    const ensureIconEl=heading=>{
+      if(!heading) return null;
+      let iconEl=heading.querySelector('i');
+      if(!iconEl){
+        iconEl=document.createElement('i');
+        iconEl.setAttribute('aria-hidden','true');
+        heading.insertBefore(iconEl, heading.firstChild||null);
+        const next=iconEl.nextSibling;
+        if(!next || next.nodeType!==Node.TEXT_NODE){
+          heading.insertBefore(document.createTextNode(' '), iconEl.nextSibling);
+        }else if(!/^\s/.test(next.textContent||'')){
+          next.textContent=' '+next.textContent;
+        }
+      }
+      return iconEl;
+    };
+
+    const moduleClasses=[];
+
+    const applyHeadingIcon=(key, raw)=>{
+      const selector=headingMap[key];
+      if(!selector) return;
+      const heading=document.querySelector(selector);
+      if(!heading) return;
+
+      let iconClass='';
+      let modules=null;
+      if(raw && typeof raw==='object' && !Array.isArray(raw)){
+        if(raw.icon) iconClass=sanitizeClasses(raw.icon);
+        if(Array.isArray(raw.modules)){
+          modules=raw.modules.map(sanitizeClasses).filter(Boolean);
+        }
+      }else{
+        iconClass=sanitizeClasses(raw);
+      }
+
+      if(iconClass){
+        const iconEl=ensureIconEl(heading);
+        if(iconEl){
+          iconEl.className=iconClass;
+          if(!iconEl.hasAttribute('aria-hidden')) iconEl.setAttribute('aria-hidden','true');
+        }
+      }
+
+      if(key==='percorso' && modules && modules.length){
+        moduleClasses.splice(0,moduleClasses.length,...modules);
+      }
+    };
+
+    Object.keys(icons).forEach(key=>{
+      if(key==='percorsoModules') return;
+      applyHeadingIcon(key, icons[key]);
+    });
+
+    if(Array.isArray(icons.percorsoModules)){
+      const sanitized=icons.percorsoModules.map(sanitizeClasses).filter(Boolean);
+      if(sanitized.length){
+        moduleClasses.splice(0,moduleClasses.length,...sanitized);
+      }
+    }
+
+    if(moduleClasses.length){
+      const moduleIcons=document.querySelectorAll('#percorso .concept-icon i');
+      moduleClasses.forEach((cls,idx)=>{
+        const iconEl=moduleIcons[idx];
+        if(iconEl && cls){
+          iconEl.className=cls;
+          if(!iconEl.hasAttribute('aria-hidden')) iconEl.setAttribute('aria-hidden','true');
+        }
+      });
+    }
+  });
   ensure('applySectionTitles', function(titles){
     if(!titles) return;
     const map = {
@@ -2797,6 +2895,7 @@ document.addEventListener('click',e=>{
     const payload=(data && typeof data==='object') ? data : {};
     const ph=payload.placeholders||{};
     applyGlobalPlaceholders(ph);
+    call('applySectionIcons', payload.sectionIcons||null);
     call('applySectionTitles', payload.sectionTitles||null);
     if(payload.image){
       const img=Object.assign({}, payload.image);

--- a/modello-import.json
+++ b/modello-import.json
@@ -105,6 +105,25 @@
     "quiz": "Sostituisci con un titolo originale per la sezione Verifica formativa su [CONCETTO_CHIAVE].",
     "glossario": "Sostituisci con un titolo originale per la sezione Glossario dedicato ai termini di [ARGOMENTO_SPECIFICO]."
   },
+  "sectionIcons": {
+    "orientamento": "fa-solid fa-book",
+    "immagine": "fa-solid fa-image",
+    "percorso": {
+      "icon": "fa-solid fa-layer-group",
+      "modules": [
+        "fa-solid fa-1",
+        "fa-solid fa-2",
+        "fa-solid fa-3"
+      ]
+    },
+    "attivazione": "fa-solid fa-bolt",
+    "primer": "fa-solid fa-rocket",
+    "schema": "fa-solid fa-sitemap",
+    "attivita": "fa-solid fa-person-chalkboard",
+    "quiz": "fa-solid fa-clipboard-list",
+    "docente": "fa-solid fa-chalkboard-user",
+    "glossario": "fa-solid fa-key"
+  },
   "image": {
     "src": "URL assoluto o relativo dell'immagine di contesto legata a [ARGOMENTO_SPECIFICO] (supporta PNG/JPG/SVG, anche data URI e link HTTPS esterni come file da Commons).",
     "ALT": "Testo alternativo (sovrascritto da ALT_IMMAGINE se presente) che descrive [DETTagLIO_VISIVO].",


### PR DESCRIPTION
## Summary
- add an ingest helper that swaps section and module icons based on JSON-provided Font Awesome classes
- wire the new icon map into the import flow and document the option in the README
- update the template and demo JSON files with sectionIcons examples for immediate reuse

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68ee4c27a45c8326a3d2e3faa60cda2d